### PR TITLE
Moved developer documentation to RM docs

### DIFF
--- a/source/developers/Plugins/Basics.html
+++ b/source/developers/Plugins/Basics.html
@@ -1,0 +1,46 @@
+---
+layout: developers
+permalink: developers/Plugin/Basics/
+title: 'Anatomy of a Plugin'
+---
+<p>Rainmeter's functionality can be expanded with the use of external plugins. Anyone with knowledge of C++ or C# can make a plugin for Rainmeter.</p>
+
+<h2 id="TheSkinWindow">Exported functions</h2>
+<div>Rainmeter plugins have a general list of functions that they must export and a few optional ones for additional functionality.<br>
+  <p>
+    <h3 id="Initialize"><i>Initialize</i></h3>
+    Called before anything on measures first load.<br>
+    Initialize your object you want to store in the data pointer here, as well as any other setup your plugin will need to do. You should also store the measure refernce here if you are going to make use of it outside Initialize or Reload.
+  </p>
+  <p>
+    <h3 id="Reload"><i>Reload</i></h3>
+    Called right after Initialize and on every update cycle of the measure if DynamicVariables=1<br>
+    Read any options from the measure in here and then doing any remaining setup that your plugin needed to do based on them.
+  </p>
+  <p>
+    <h3 id="Update"><i>Update</i></h3>
+    Called on every update cycle of the measure<br>
+    Return the value you want to use as the number value of the measure here. You should do anything that requires being run regularly here
+  </p>
+  <p>
+    <h3 id="GetString"><i>GetString</i> (Optional)</h3>
+    Called as the string value of the measure is used in any meters or measures<br>
+    Return the value you want to use as the string value of the measure here. You should do absolutely no processing here as it is possible to have this called multiple times an update. Instead calculate any values in update and just return them here.
+  </p>
+  <p>
+    <h3 id="ExecuteBang"><i>ExecuteBang</i> (Optional)</h3>
+    Called whenever a !CommandMeasure bang is used<br>
+    Incredibly useful for interacting with your plugin. Media playback plugins are a good example of using this, so then a skin could have a button to pause the music on command.
+  </p>
+  <p>
+    <h3 id="SectionVariables"><i>SectionVariables</i> (Optional)</h3>
+    Called whenever a section variables is used ex. [&pluginMeasure:func(arg1, arg2)]<br>
+    While similar to ExecuteBang this has the added nicety of being able to return a value. Note that Rainmeter prevents these from being called before Initialization so data will be setup.
+  </p>
+  <p>
+    <h3 id="Finalize"><i>Finalize</i></h3>
+    Called whenever a measure is unloaded<br>
+    Deallocate anything here to prevent memory leaks. Note that on skin reload finalize and initalize will both be called right after eachother.
+  </p>
+  </ul>
+</div><br>

--- a/source/developers/Plugins/Best-Practices.html
+++ b/source/developers/Plugins/Best-Practices.html
@@ -1,0 +1,55 @@
+---
+layout: developers
+permalink: developers/Plugin/Best-Practices/
+title: 'Plugin Best Practices'
+---
+<p>After you make Rainmeter plugins for long enough you start to learn a lot of things you could have done better in your earlier plugins. This should help serve as a guide so you have as little of those moments as possible</p>
+
+<p>
+  <h3 id="Multithreading">Multithreading and Rainmeter</h3>
+  <p>While Rainmeter skins are serial it is possible to have a multithreaded plugin, however you need should be careful of a few things.</p>
+  <ul>
+    <li>Measures in Rainmeter can be paused or disabled to prevent CPU usage, thus you may want to avoid doing heavy compute where possible when they are disabled/paused.</li>
+    <li>GetString gets new strings on demand, thus if you update what is returned in GetString it is possible to have GetString change before Update and have GetString ignore being paused or disabled</li>
+  </ul>
+</p>
+<p>
+  <h3 id="Marshalling">C# Plugins and Marshalling</h3>
+  <p>When making C# plugins you may notice references to IntPtr's and Marshal functions. Since Rainmeter is written is C++ variables are encoded different, but dont be intimidated by them.</p>
+  <p>An IntPtr is simply a pointer to C++ style data, which is why you must dealocate data in finalize as well as recast it in every function. Also since string are formatted differently in C++ you should pass your string to Marshal.StringToHGlobalUni before returning it in GetString or SectionVariables.</p>
+  <p>Also the MarshalAs in ExecuteBang and SectionVariable examples just makes sure that you get a C# style string or string array out of the box.</p>
+</p>
+<p>
+  <h3 id="CustomBangs">Adding custom bangs</h3>
+  <p>Many plugins add support for custom bangs so if you find that you have funcitonality that you want a button click to activate or just want to skins to avoid a lot of !SetOption bangs adding custom !CommandMeasureBangs may be useful.</p>
+  <p>However you should note that you are given the raw string from the command so you should be careful of odd capitalization and if you are going to add more complex commands you will need to parse the arguments yourself.</p>
+</p>
+<p>
+  <h3 id="SectionVariables">Section Variables</h3>
+  <p>One of the cool new features of Rainmeter is section variables. This allows Lua scripts and plugins to be called "inline", however unlike Lua scripts plugins must explicitly add support for it. While at first glance it may seem no difference than custom bangs they are way more powerful and you can return a value. Any value your return will replace the variable, and if you decide you dont want to replace it you can just return null.</p>
+  <p>Any function besides the default functions that you export can be used as a section variable, so you may add as many as you like. Make sure though that you document them so that people know how to use them and what arguments they need to give if any.</p>
+</p>
+<p>
+  <h3 id="DynamicVariables">Dynamic Variables</h3>
+  <p>A lot of skin creators can be overzealous about turning on DynamicVariables thus even if you think it is unneeded for your plugin you should try to optimize your skin for if someone does turn them on. Common optimzations include:</p>
+  <ul>
+    <li>Moving anything in Reload that does not require an option being read to Initialization.</li>
+    <li>Caching the last known values of options that would require more a lot of computation so you do not redo setup when no options have changed.</li>
+    <li>Adding custom events that can fire bangs, this will allow skin developers to avoid using Dynamic Variables on measures that rely on your plugin. You do this by reading an option you have named for the event and then you fire it when it is time to by passing that string to RmExecute.</li>
+  </ul>
+</p>
+<p>
+  <h3>Taking advantage of data argument</h3>
+  <p>You might notice that every single function you can implement that Rainmeter can call has a argument called data. This is for your convenience and will allow to save and change info in it for later.</p>
+  <p>In all of our examples you will find that we use a Measure structure/class and set data to an instance of one Initialize. So if you use this approach then you can set/change/use variables that are in that structure in any function and it will stay specific to that measure.</p>
+</p>
+<p>
+  <h3>Saving info in the Rainmeter.data file for later</h3>
+  <p>So you may have a plugin you want to make that has data that would persist across measure and skins and be saved for later. If you do want to do this we recommend storing that data in the Rainmeter.data file.</p>
+  <p>A link to the Rainmeter.data file can be retrieved by calling RmGetSettingsFile, make sure you are using a unique key that another plugin will not also use for any data you have in there. We then recommend using <a href=https://msdn.microsoft.com/en-us/library/windows/desktop/ms724353(v=vs.85).aspx>GetPrivateProfileString</a> and <a href=https://msdn.microsoft.com/en-us/library/windows/desktop/ms725501(v=vs.85).aspx>WritePrivateProfileString</a> for getting and setting data store there.</p>
+</p>
+<p>
+  <h3>Where to save the rm reference</h3>
+  <p>While you are given the reference to the measure (the pointer called rm) in both Initialize or Reload, if you need it later for logging purposes then you should save the one given in initialize as saving it in reload can cause unneeded overhead of DynamicVariables=1.</p>
+  <p>You should always save it for later when you have logging in outside of reload so that the logging statements you give will have a context.<p/>
+</p>

--- a/source/developers/Plugins/C++/API-Reference.html
+++ b/source/developers/Plugins/C++/API-Reference.html
@@ -1,0 +1,209 @@
+---
+layout: developers
+permalink: developers/Plugin/C++-Reference/API-Reference/
+title: 'C++ API Overview'
+---
+<p>This is an overview of the functions available in C++ SDK for Rainmeter.</p>
+<p>Note that summaries are also provided in the API libraries</p>
+
+<dt id="ReadString"><code>RmReadString</code> <small><code>LPCWSTR ReadString(void* rm, LPCWSTR option, LPCWSTR defValue, BOOL replaceMeasures = TRUE)</code></small></dt>
+<dd>
+  <p>Returns a string representation of an option</p>
+  <p>
+    <i>rm:</i> <code>Pointer to the plugin measure</code><br>
+    <i>option:</i> <code>Option name to be read from skin</code><br>
+    <i>defValue:</i> <code>Default value for the option if it is not found or invalid</code><br>
+    <i>replaceMeasures:</i> <code>(Optional) If true, replaces section variables in the returned string</code>
+  </p>
+  ```C
+  PLUGIN_EXPORT void Reload(void* data, void* rm, double* maxValue)
+  {
+      LPCWSTR value = RmReadString(rm, L"Value", L"DefaultValue");
+      LPCWSTR action = RmReadString(rm, L"Action", L"", FALSE);
+        // [MeasureNames] will be parsed/replaced when the action is executed with RmExecute
+  }
+  ```
+</dd>
+<dt id="ReadPath"><code>RmReadPath</code> <small><code>LPCWSTR RmReadPath(void* rm, LPCWSTR option, LPCWSTR defValue)</code></small></dt>
+<dd>
+  <p>Retrieves the option defined in the skin file and converts a relative path to a absolute path</p>
+  <p>
+    <i>rm:</i> <code>Pointer to the plugin measure</code><br>
+    <i>option:</i> <code>Option name to be read from skin</code><br>
+    <i>defValue:</i> <code>Default value for the option if it is not found or invalid</code>
+  </p>
+  ```C
+  PLUGIN_EXPORT void Reload(void* data, void* rm, double* maxValue)
+  {
+      LPCWSTR path = RmReadPath(rm, L"MyPath", L"C:\\");
+  }
+  ```
+</dd>
+<dt id="ReadDouble"><code>RmReadDouble</code> <small><code>double RmReadDouble(void* rm, LPCWSTR option, double defValue)</code></small></dt>
+<dd>
+  <p>Retrieves the option defined in the skin file and converts it to a double</p>
+  <p>
+    <i>rm:</i> <code>Pointer to the plugin measure</code><br>
+    <i>option:</i> <code>Option name to be read from skin</code><br>
+    <i>defValue:</i> <code>Default value for the option if it is not found, invalid, or a formula could not be parsed</code>
+  </p>
+  ```C
+  PLUGIN_EXPORT void Reload(void* data, void* rm, double* maxValue)
+  {
+      double value = RmReadDouble(rm, L"Value", 20.0);
+  }
+  ```
+</dd>
+<dt id="ReadInt"><code>RmReadInt</code> <small><code>int RmReadInt(void* rm, LPCWSTR option, int defValue)</code></small></dt>
+<dd>
+  <p>Retrieves the option defined in the skin file and converts it to an integer</p>
+  <p>
+    <i>rm:</i> <code>Pointer to the plugin measure</code><br>
+    <i>option:</i> <code>Option name to be read from skin</code><br>
+    <i>defValue:</i> <code>Default value for the option if it is not found, invalid, or a formula could not be parsed</code>
+  </p>
+  ```C
+  PLUGIN_EXPORT void Reload(void* data, void* rm, double* maxValue)
+  {
+      int value = RmReadInt(rm, L"Value", 20);
+  }
+  ```
+</dd>
+<dt id="Execute"><code>RmExecute</code> <small><code>void RmExecute(void* skin, LPCWSTR command)</code></small></dt>
+<dd>
+  <p>Executes a command</p>
+  <p>
+    <i>skin:</i> <code>Pointer to current skin (See API.GetSkin)</code><br>
+    <i>command:</i> <code>Bang to execute</code>
+  </p>
+  ```C
+  PLUGIN_EXPORT double Update(void* data)
+  {
+      Measure* measure = (Measure*)data;
+      RmExecute(measure->skin, L"!SetVariable SomeVar 10");
+        // 'measure->skin' stored previously in the Initialize function
+      return 0.0;
+  }
+  ```
+</dd>
+<dt id="ReplaceVariables"><code>RmReplaceVariables</code> <small><code>LPCWSTR RmReplaceVariables(void* rm, LPCWSTR str)</code></small></dt>
+<dd>
+  <p>Returns a string, replacing any variables (or section variables) within the inputted string</p>
+  <p>
+    <i>rm:</i> <code>Pointer to the plugin measure</code><br>
+    <i>str:</i> <code>String with unresolved variables</code>
+  </p>
+  ```C
+  PLUGIN_EXPORT double Update(void* data)
+  {
+      Measure* measure = (Measure*)data;
+      LPCWSTR myVar = RmReplaceVariables(measure->rm, L"#MyVar#");
+        // 'measure->rm' stored previously in the Initialize function
+      if (_wcsicmp(myVar, L"SOMETHING") == 0) { return 1.0; }
+      return 0.0;
+  }
+  ```
+</dd>
+<dt id="GetMeasureName"><code>RmGetMeasureName</code> <small><code>LPCWSTR RmGetMeasureName(void* rm)</code></small></dt>
+<dd>
+  <p>Retrieves the name of the measure</p>
+  <p>
+    <i>rm:</i> <code>Pointer to the plugin measure</code>
+  </p>
+  ```C
+  PLUGIN_EXPORT void Initialize(void** data, void* rm)
+  {
+      Measure* measure = new Measure;
+      *data = measure;
+      measure->myName = RmGetMeasureName(rm);
+        // 'measure->myName' defined as a string (LPCWSTR) in class scope
+  }
+  ```
+</dd>
+<dt id="GetSkin"><code>RmGetSkin</code> <small><code>void* RmGetSkin(void* rm)</code></small></dt>
+<dd>
+  <p>Retrieves an internal pointer to the current skin</p>
+  <p>
+    <i>rm:</i> <code>Pointer to the plugin measure</code>
+  </p>
+  ```C
+  PLUGIN_EXPORT void Initialize(void** data, void* rm)
+  {
+      Measure* measure = new Measure;
+      *data = measure;
+      measure->mySkin = RmGetSkin(rm);
+        // 'measure->mySkin' defined as a 'void*' in class scope
+  }
+  ```
+</dd>
+<dt id="GetSettingsFile"><code>RmGetSettingsFile</code> <small><code>LPCWSTR GetSettingsFile()</code></small></dt>
+<dd>
+  <p>Retrieves a path to the Rainmeter data file (Rainmeter.data)</p>
+  ```C
+  PLUGIN_EXPORT void Initialize(void** data, void* rm)
+  {
+      Measure* measure = new Measure;
+      *data = measure;
+      if (rmDataFile == nullptr) { rmDataFile = RmGetSettingsFile(); }
+        // 'rmDataFile' defined as a string (LPCWSTR) in global scope
+  }
+  ```
+</dd>
+<dt id="GetSkinName"><code>RmGetSkinName</code> <small><code>LPCWSTR RmGetSkinName(void* rm)</code></small></dt>
+<dd>
+  <p>Retrieves full path and name of the skin</p>
+  <p>
+    <i>rm:</i> <code>Pointer to the plugin measure</code>
+  </p>
+  ```C
+  PLUGIN_EXPORT void Initialize(void** data, void* rm)
+  {
+      Measure* measure = new Measure;
+      *data = measure;
+      skinName = RmGetSkinName(rm); }
+        // 'measure->skinName' defined as a string (LPCWSTR) in class scope
+  }
+  ```
+</dd>
+<dt id="GetSkinWindow"><code>RmGetSkinWindow</code> <small><code>HWND RmGetSkinWindow(void* rm)</code></small></dt>
+<dd>
+  <p>Returns a pointer to the handle of the skin window (HWND)</p>
+  <p>
+    <i>rm:</i> <code>Pointer to the plugin measure</code>
+  </p>
+  ```C
+  PLUGIN_EXPORT void Initialize(void** data, void* rm)
+  {
+      Measure* measure = new Measure;
+      *data = measure;
+      measure->skinWindow = RmGetSkinWindow(rm); }
+        // 'measure->skinWindow' defined as HWND in class scope
+  }
+  ```
+</dd>
+<dt id="Log"><code>RmLog</code> <small><code>void RmLog(void* rm, int level, LPCWSTR message)</code></small></dt>
+<dd>
+  <p>Sends a message to the Rainmeter log with source</p>
+  <p>
+    <i>rm:</i> <code>Pointer to the plugin measure</code><br>
+    <i>type:</i> <code>Log level (API.LogType of Error, Warning, Notice, or Debug)</code><br>
+    <i>message:</i> <code>Message to be logged</code>
+  </p>
+  ```C
+  RmLog(rm, LOG_NOTICE, L"I am a 'notice' log message with a source");
+  ```
+</dd>
+<dt id="LogF"><code>RmLogF</code> <small><code>void RmLogF(void* rm, int level, LPCWSTR format, ...)</code></small></dt>
+<dd>
+  <p>Sends a formatted message to the Rainmeter log</p>
+  <p>
+    <i>rm:</i> <code>Pointer to the plugin measure</code><br>
+    <i>type:</i> <code>Log level (API.LogType of Error, Warning, Notice, or Debug)</code><br>
+    <i>format:</i> <code>Formatted message to be logged, follows printf syntax</code><br>
+    <i>args:</i> <code>Comma separated list of args referenced in the formatted message</code>
+  </p>
+  ```C
+  std::wstring notice = L"notice";
+  RmLogF(rm, LOG_NOTICE, L"I am a '%s' log message with a source", notice.c_str());
+  ```
+</dd>

--- a/source/developers/Plugins/C++/Plugin-Reference.html
+++ b/source/developers/Plugins/C++/Plugin-Reference.html
@@ -1,0 +1,129 @@
+---
+layout: developers
+permalink: developers/Plugin/C++-Reference/
+title: 'Making a C++ Plugin'
+---
+<p>When making a Rainmeter plugin there are a some basic functions that your code must export, as well as several optional ones you may want to export.</p>
+
+<p>A copy of the API with some examples can be found <a href="https://github.com/rainmeter/rainmeter-plugin-sdk">here</a> as well as the basics of each function listed bellow:</p>
+<dt id="Initialize"><code>Initialize</code> <small><code>void Initialize(void** data, void* rm)</code></small></dt>
+<dd>
+  <p>Called when a measure is created (i.e. when Rainmeter is launched or when a skin is refreshed). Initialize your measure object here. If you need to save your measure reference that should also be done here</p>
+  <p>
+    <i>data:</i> <code>You may allocate and store measure-specific data in here</code><br>
+    <i>rm:</i> <code>Internal pointer that is passed to most Rm functions, can be saved for later</code>
+  </p>
+  ```C
+  PLUGIN_EXPORT void Initialize(void** data, void* rm)
+  {
+    	Measure* measure = new Measure;
+      //Do any init here, saving any values you want to into data for later
+    	*data = measure;
+  }
+  ```
+</dd>
+<dt id="Finalize"><code>Finalize</code> <small><code>void Finalize(void* data)</code></small></dt>
+<dd>
+  <p>Called by Rainmeter when a measure is about to be destroyed. Perform cleanup here.</p>
+  <p>
+    <i>data:</i> <code>Pointer to whatever data was set to in Initialize</code>
+  </p>
+  ```
+  PLUGIN_EXPORT void Finalize(void* data)
+  {
+    	Measure* measure = (Measure*)data;
+      //Do any cleanup here
+    	delete measure;
+  }
+  ```
+</dd>
+<dt id="Reload"><code>Reload</code> <small><code>void Reload(void* data, void* rm, double* maxValue)</code></small></dt>
+<dd>
+  <p>Called by Rainmeter when the measure settings are to be read directly after Initialize. This function must be exported. If DynamicVariables=1 is set on the measure, Reload is called before every update cycle.</p>
+  <p>
+    <i>data:</i> <code>You may allocate and store measure-specific data in here</code><br>
+    <i>rm:</i> <code>Internal pointer that is passed to most Rm functions</code><br>
+    <i>maxValue:</i> <code>Whatever the maximum possible value of update will be for this measure. Used to for autoscaling. 0 will make it based on the highest value in update. Do not set maxValue unless necessary.</code>
+  </p>
+  ```C
+  PLUGIN_EXPORT void Reload(void* data, void* rm, double* maxValue)
+  {
+  	 Measure* measure = (Measure*)data;
+     //Read options here
+  }
+  ```
+</dd>
+<dt id="Update"><code>Update</code> <small><code>double Update(void* data)</code></small></dt>
+<dd>
+  <p>Called by Rainmeter when a measure value is to be updated (i.e. once on each update cycle). Return the new value.</p>
+  <p>
+    <i>data:</i> <code>Pointer to whatever data was set to in Initialize</code>
+  </p>
+  <p><i>returns:</i> <code>Number value for the measure, if no string value defined it will also be used for string values</code></p>
+  ```C
+  PLUGIN_EXPORT double Update(void* data)
+  {
+    	Measure* measure = (Measure*)data;
+      //Any processing that needs to happen often should happen here
+    	return 0.0; //return whatever you want to use as a number value for this measure
+  }
+  ```
+</dd>
+<dt id="GetString"><code>GetString (Optional)</code> <small><code>LPCWSTR GetString(void* data)</code></small></dt>
+<dd>
+  <p>Called on-demand (in other words, may be called multiple times or not at all during a update cycle). Return the string value for the measure here. Do not process data or consume CPU time in this function, instead do processing for string values in update.</br>
+  <p>
+    <i>data:</i> <code>Pointer to whatever data was set to in Initialize</code>
+  </p>
+  <p><i>returns:</i> <code>String value for the measure, if null number value is used instead.</code></p>
+  ```C
+  PLUGIN_EXPORT LPCWSTR GetString(void* data)
+  {
+    	Measure* measure = (Measure*)data;
+      if(something)
+      {
+          //return a string value to use for this measure
+          return L"SomeValue";
+      }
+      //Return null when you only want a number value for this measure
+	     return nullptr;
+  }
+  ```
+</dd>
+<dt id="ExecuteBang"><code>ExecuteBang (Optional)</code> <small><code>void ExecuteBang(void* data, LPCWSTR args)</code></small></dt>
+<dd>
+  <p>Called by Rainmeter when a !CommandMeasure bang is sent to the measure. This can be used to change some data within the measure, or to interact with another application. .</p>
+  <p>
+    <i>data:</i> <code>Option name to be read from skin</code><br>
+    <i>args:</i> <code>Command string sent from Rainmeter using !CommandMeasure, all variables have been resolved. Removing MashalAs will allo</code>
+  </p>
+  ```
+  PLUGIN_EXPORT void ExecuteBang(void* data, LPCWSTR args)
+  {
+      Measure* measure = (Measure*)data;
+  }
+  ```
+</dd>
+<dt id="SectionVariables"><code>Section Variable(s) (Optional)</code> <small><code> LPCWSTR func(void* data, const int argc, const WCHAR* argv[] argv)</code></small></dt>
+<dd>
+  <p>Called by Rainmeter when a section variable is used, ex. [&pluginMeasure:func(arg1, arg2)] where func is the function you want called, any non standard function you export can be used. Whatever value you return will replace that value</p>
+  <p>
+    <i>data:</i> <code>Option name to be read from skin</code><br>
+    <i>argc:</i> <code>Number of arguments passed to function</code><br>
+    <i>argv:</i> <code>Array of arguments passed to function</code>
+  </p>
+  <p><i>returns:</i> <code>LPCWSTR to replace section variable with, if null it will be unchanged.</code></p>
+  ```C
+  PLUGIN_EXPORT LPCWSTR SomeFunction(void* rm, const int argc, const WCHAR* argv[] argv)
+  {
+      Measure measure = (Measure)data;
+      if(argc > 0)
+      {
+          //Do something and return a value to replace variable with
+          return doSomething(argv);
+      }
+      //If null returned then dont replace variable
+      return nullptr;
+  }
+  ```
+</dd>

--- a/source/developers/Plugins/CSharp/API-Reference.html
+++ b/source/developers/Plugins/CSharp/API-Reference.html
@@ -1,0 +1,176 @@
+---
+layout: developers
+permalink: developers/Plugin/CSharp-Reference/API-Reference/
+title: 'C# API Overview'
+---
+<p>This is an overview of the functions available in the C# Rainmeter API. All the functions are behind a Rainmeter.API wrapper which is created using the rm IntPtr</p>
+<p>Note that summaries are also provided in the API libraries</p>
+
+<dt id="ReadString"><code>ReadString</code> <small><code>string ReadString(string option, string defValue, bool replaceMeasures = true)</code></small></dt>
+<dd>
+  <p>Returns a string representation of an option</p>
+  <p>
+    <i>option:</i> <code>Option name to be read from skin</code><br>
+    <i>defValue:</i> <code>Default value for the option if it is not found or invalid</code><br>
+    <i>replaceMeasures:</i> <code>(Optional) If true, replaces section variables in the returned string</code>
+  </p>
+  ```C
+  internal void Reload(Rainmeter.API rm, ref double maxValue)
+  {
+      string value = rm.ReadString("Value", "DefaultValue");
+      string action = rm.ReadString("Action", "", false);
+        // [MeasureNames] will be parsed/replaced when the action is executed with API.Execute
+  }
+  ```
+</dd>
+<dt id="ReadPath"><code>ReadPath</code> <small><code>string ReadPath(string option, string defValue)</code></small></dt>
+<dd>
+  <p>Retrieves the option defined in the skin file and converts a relative path to a absolute path</p>
+  <p>
+    <i>option:</i> <code>Option name to be read from skin</code><br>
+    <i>defValue:</i> <code>Default value for the option if it is not found or invalid</code>
+  </p>
+  ```C
+  internal void Reload(Rainmeter.API rm, ref double maxValue)
+  {
+      string path = rm.ReadPath("MyPath", "C:\\");
+  }
+  ```
+</dd>
+<dt id="ReadDouble"><code>ReadDouble</code> <small><code>double ReadDouble(string option, double defValue)</code></small></dt>
+<dd>
+  <p>Retrieves the option defined in the skin file and converts it to a double</p>
+  <p>
+    <i>option:</i> <code>Option name to be read from skin</code><br>
+    <i>defValue:</i> <code>Default value for the option if it is not found, invalid, or a formula could not be parsed</code>
+  </p>
+  ```C
+  internal void Reload(Rainmeter.API rm, ref double maxValue)
+  {
+      double value = rm.ReadDouble("Value", 20.0);
+  }
+  ```
+</dd>
+<dt id="ReadInt"><code>ReadInt</code> <small><code>int ReadInt(string option, int defValue)</code></small></dt>
+<dd>
+  <p>Retrieves the option defined in the skin file and converts it to an integer</p>
+  <p>
+    <i>option:</i> <code>Option name to be read from skin</code><br>
+    <i>defValue:</i> <code>Default value for the option if it is not found, invalid, or a formula could not be parsed</code>
+  </p>
+  ```C
+  internal void Reload(Rainmeter.API rm, ref double maxValue)
+  {
+      int value = rm.ReadInt("Value", 20);
+  }
+  ```
+</dd>
+<dt id="Execute"><code>Execute</code> <small><code>static void Execute(IntPtr skin, string command)</code></small></dt>
+<dd>
+  <p>Executes a command</p>
+  <p>
+    <i>skin:</i> <code>Pointer to current skin (See API.GetSkin)</code><br>
+    <i>command:</i> <code>Bang to execute</code>
+  </p>
+  ```C
+  internal double Update(IntPtr data)
+  {
+      Measure measure = (Measure)data;
+      Rainmeter.API(measure->skin, L"!SetVariable SomeVar 10");
+        // 'measure->skin' stored previously in the Initialize function
+      return 0.0;
+  }
+  ```
+</dd>
+<dt id="ReplaceVariables"><code>ReplaceVariables</code> <small><code>string ReplaceVariables(string str)</code></small></dt>
+<dd>
+  <p>Returns a string, replacing any variables (or section variables) within the inputted string</p>
+  <p>
+    <i>str:</i> <code>String with unresolved variables</code>
+  </p>
+  ```C
+  internal double Update()
+  {
+      string myVar = ReplaceVariables("#MyVar#").ToUpperInvariant();
+      if (myVar == "SOMETHING") { return 1.0; }
+      return 0.0;
+  }
+  ```
+</dd>
+<dt id="GetMeasureName"><code>GetMeasureName</code> <small><code>string GetMeasureName()</code></small></dt>
+<dd>
+  <p>Retrieves the name of the measure</p>
+  ```C
+  internal void Initialize(Rainmeter.API rm)
+  {
+      myName = GetMeasureName();  // declare 'myName' as a string in class scope
+  }
+  ```
+</dd>
+<dt id="GetSkin"><code>GetSkin</code> <small><code>IntPtr GetSkin()</code></small></dt>
+<dd>
+  <p>Retrieves an internal pointer to the current skin</p>
+  ```C
+  internal void Initialize(Rainmeter.API rm)
+  {
+      mySkin = GetSkin();  // declare 'mySkin' as a IntPtr in class scope
+  }
+  ```
+</dd>
+<dt id="GetSettingsFile"><code>GetSettingsFile</code> <small><code>string GetSettingsFile()</code></small></dt>
+<dd>
+  <p>Retrieves a path to the Rainmeter data file (Rainmeter.data)</p>
+  ```C
+  internal void Initialize(Rainmeter.API rm)
+  {
+      if (rmDataFile == null) { rmDataFile = GetSettingsFile(); }
+        // declare 'rmDataFile' as a string in global scope
+  }
+  ```
+</dd>
+<dt id="GetSkinName"><code>GetSkinName</code> <small><code>string GetSkinName()</code></small></dt>
+<dd>
+  <p>Retrieves full path and name of the skin</p>
+  ```C
+  internal void Initialize(Rainmeter.API rm)
+  {
+      skinName = GetSkinName(); }  // declare 'skinName' as a string in class scope
+  }
+  ```
+</dd>
+<dt id="GetSkinWindow"><code>GetSkinWindow</code> <small><code>IntPtr GetSkinWindow()</code></small></dt>
+<dd>
+  <p>Returns a pointer to the handle of the skin window (HWND)</p>
+  ```C
+  internal void Initialize(Rainmeter.API rm)
+  {
+      skinWindow = GetSkinWindow(); }  // declare 'skinWindow' as a IntPtr in class scope
+  }
+  ```
+</dd>
+<dt id="Log"><code>Log</code> <small><code>static void Log(IntPtr rm, LogType type, string message)</code></small></dt>
+<dd>
+  <p>Sends a message to the Rainmeter log with source</p>
+  <p>
+    <i>rm:</i> <code>Pointer to the plugin measure (Or Rainmeter.API object)</code><br>
+    <i>type:</i> <code>Log level (API.LogType of Error, Warning, Notice, or Debug)</code><br>
+    <i>message:</i> <code>Message to be logged</code>
+  </p>
+  ```C
+  Log(rm, LOG_NOTICE, "I am a 'notice' log message with a source");
+  ```
+</dd>
+<dt id="LogF"><code>LogF</code> <small><code>static void LogF(IntPtr rm, LogType type, string format, params string[] args)</code></small></dt>
+<dd>
+  <p>Sends a formatted message to the Rainmeter log</p>
+  <p>
+    <i>rm:</i> <code>Pointer to the plugin measure (Or Rainmeter.API object)</code><br>
+    <i>type:</i> <code>Log level (API.LogType of Error, Warning, Notice, or Debug)</code><br>
+    <i>format:</i> <code>Formatted message to be logged, follows printf syntax</code><br>
+    <i>args:</i> <code>Comma separated list of args referenced in the formatted message</code>
+  </p>
+  ```C
+  string notice = "notice";
+  LogF(rm, LOG_NOTICE, "I am a '%s' log message with a source", notice);
+  ```
+</dd>

--- a/source/developers/Plugins/CSharp/Plugin-Reference.html
+++ b/source/developers/Plugins/CSharp/Plugin-Reference.html
@@ -1,0 +1,143 @@
+---
+layout: developers
+permalink: developers/Plugin/CSharp-Reference/
+title: 'Making a C# Plugin'
+---
+<p>When making a Rainmeter plugin there are a some basic functions that your code must export, as well as several optional ones you may want to export.</p>
+
+<p>A copy of the API with some examples can be found <a href="https://github.com/rainmeter/rainmeter-plugin-sdk">here</a> as well as the basics of each function listed bellow:</p>
+<dt id="Initialize"><code>Initialize</code> <small><code>void Initialize(ref IntPtr data, IntPtr rm)</code></small></dt>
+<dd>
+  <p>Called when a measure is created (i.e. when Rainmeter is launched or when a skin is refreshed). Initialize your measure object here. If you need to save your measure reference that should also be done here</p>
+  <p>
+    <i>data:</i> <code>You may allocate and store measure-specific data in here</code><br>
+    <i>rm:</i> <code>Internal pointer that should can be used to make a Rainmeter.API object. Used to call certain Rm functions, can be saved for later</code>
+  </p>
+  ```C
+  [DllExport]
+  public static void Initialize(ref IntPtr data, IntPtr rm)
+  {
+      Measure measure = new Measure();
+      //Do any init here, saving any values you want to into data for later
+      data = GCHandle.ToIntPtr(GCHandle.Alloc(measure));
+      Rainmeter.API api = (Rainmeter.API)rm;
+  }
+  ```
+</dd>
+<dt id="Finalize"><code>Finalize</code> <small><code>void Finalize(IntPtr data)</code></small></dt>
+<dd>
+  <p>Called by Rainmeter when a measure is about to be destroyed. Perform cleanup here.</p>
+  <p>
+    <i>data:</i> <code>Pointer to whatever data was set to in Initialize</code>
+  </p>
+  ```
+  [DllExport]
+  public static void Finalize(IntPtr data)
+  {
+      Measure measure = (Measure)data;
+      //Do any cleanup here
+      GCHandle.FromIntPtr(data).Free();
+  }
+  ```
+</dd>
+<dt id="Reload"><code>Reload</code> <small><code>void Reload(IntPtr data, IntPtr rm, ref double maxValue)</code></small></dt>
+<dd>
+  <p>Called by Rainmeter when the measure settings are to be read directly after Initialize. This function must be exported. If DynamicVariables=1 is set on the measure, Reload is called before every update cycle.</p>
+  <p>
+    <i>data:</i> <code>You may allocate and store measure-specific data in here</code><br>
+    <i>rm:</i> <code>Internal pointer that should can be used to make a Rainmeter.API object. Used to call certain Rm functions</code><br>
+    <i>maxValue:</i> <code>Whatever the maximum possible value of update will be for this measure. Used to for autoscaling. 0 will make it based on the highest value in update. Do not set maxValue unless necessary.</code>
+  </p>
+  ```C
+  [DllExport]
+  public static void Reload(IntPtr data, IntPtr rm, ref double maxValue)
+  {
+      Measure measure = (Measure)data;
+      //Read options here
+  }
+  ```
+</dd>
+<dt id="Update"><code>Update</code> <small><code>double Update(IntPtr data)</code></small></dt>
+<dd>
+  <p>Called by Rainmeter when a measure value is to be updated (i.e. once on each update cycle). Return the new value.</p>
+  <p>
+    <i>data:</i> <code>Pointer to whatever data was set to in Initialize</code>
+  </p>
+  <p><i>returns:</i> <code>Number value for the measure, if no string value defined it will also be used for string values</code></p>
+  ```C
+  [DllExport]
+  public static double Update(IntPtr data)
+  {
+      Measure measure = (Measure)data;
+      //Any processing that needs to happen often should happen here
+      return 0.0; //return whatever value you want rainmeter to display here
+  }
+  ```
+</dd>
+<dt id="GetString"><code>GetString (Optional)</code> <small><code>String GetString(IntPtr data)</code></small></dt>
+<dd>
+  <p>Called on-demand (in other words, may be called multiple times or not at all during a update cycle). Return the string value for the measure here. Do not process data or consume CPU time in this function, instead do processing for string values in update.</br>
+  <p>
+    <i>data:</i> <code>Pointer to whatever data was set to in Initialize</code>
+  </p>
+  <p><i>returns:</i> <code>String value for the measure, if null number value is used instead. Must be marshalled from a C# style string to a WCHAR*</code></p>
+  ```C
+  [DllExport]
+  public static IntPtr GetString(IntPtr data)
+  {
+      Measure measure = (Measure)data;
+      if(something)
+      {
+          //return a string value to use for this measure
+          //Notice how you must marshal it back and can not use a return MarshalAs
+          return Marshal.StringToHGlobalUni("SomeValue");
+      }
+      //Return null whenyou only want a number value for this measure
+      return IntPtr.Zero;
+  }
+  ```
+</dd>
+<dt id="ExecuteBang"><code>ExecuteBang (Optional)</code> <small><code>void ExecuteBang(IntPtr data, string args)</code></small></dt>
+<dd>
+  <p>Called by Rainmeter when a !CommandMeasure bang is sent to the measure. This can be used to change some data within the measure, or to interact with another application. .</p>
+  <p><b>Note:</b> args is a LPCWSTR in C++ an thus must be marshalled to a C# style string</p>
+  <p>
+    <i>data:</i> <code>Option name to be read from skin</code><br>
+    <i>args:</i> <code>Command string sent from Rainmeter using !CommandMeasure, all variables have been resolved.</code>
+  </p>
+  ```C
+  [DllExport]
+  public static void ExecuteBang(IntPtr data, [MarshalAs(UnmanagedType.LPWStr)]String args)
+  {
+      Measure measure = (Measure)data;
+      //Do something based on args here
+  }
+  ```
+</dd>
+<dt id="SectionVariables"><code>Section Variable(s) (Optional)</code> <small><code>static string func(IntPtr data, int argc, string[] argv)</code></small></dt>
+<dd>
+  <p>Called by Rainmeter when a section variable is used, ex. [&pluginMeasure:func(arg1, arg2)] where func is the function you want called, any non standard function you export can be used. Whatever value you return will replace that value</p>
+  <p><b>Note:</b> argv is a LPCWSTR in C++ and thus must be marshalled to a C# style string </p>
+  <p>
+    <i>data:</i> <code>Option name to be read from skin</code><br>
+    <i>argc:</i> <code>Number of arguments passed to function</code><br>
+    <i>argv:</i> <code>Array of arguments passed to function</code>
+  </p>
+  <p><i>returns:</i> <code>String to replace section variable with, if null it will be unchanged. Must be marshalled from a C# style string to a LPCWSTR</code></p>
+  ```C
+  [DllExport]
+  public static IntPtr ToLower(IntPtr data, int argc,
+      [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr, SizeParamIndex = 2)] string[] argv)
+  {
+      Measure measure = (Measure)data;
+      if(argc > 0)
+      {
+          //Do something and return a value to replace variable with
+          //Notice how you must marshal it back and can not use a return MarshalAs
+          return Marshal.StringToHGlobalUni(doSomething(argv));
+      }
+      //If null returned then dont replace variable
+      return IntPtr.Zero;
+  }
+  ```
+</dd>

--- a/source/developers/index.html
+++ b/source/developers/index.html
@@ -55,7 +55,7 @@ set CERTKEY=certpassword
 <p>Anyone can create and distribute <a href="/manual/plugins/#Custom">custom plugins</a> for Rainmeter.</p>
 
 <p><b>Note:</b> The Rainmeter Skin Installer program, which is used by end-users to install the skins containing your plugin, will not allow the same or older version of the plugin to overwrite a newer version. The means that it is critically important that every release of your plugin must have the "File version" number incremented. If you don't do this, your plugin will not be distributed.</p>
- 
+
 <p>The only software you will need is <b>Microsoft Visual Studio 2017</b> or the free <b>Microsoft Visual Community</b> which can be obtained at <a href="http://www.visualstudio.com/downloads/download-visual-studio-vs">Download Visual Studio</a>. Be sure to download and apply any Visual Studio Updates when prompted.</p>
 
 <p>Then you will want to download the <a href="https://github.com/rainmeter/rainmeter-plugin-sdk">Rainmeter Plugin SDK</a> to a folder on your PC. The SDK contains the API code needed to create plugins, as well as some starting and sample plugin code for C++ and C#:</p>
@@ -67,6 +67,8 @@ An empty plugin template you can use as a starting point for your code.</li>
 An example plugin that returns the Windows system version to a skin.</li>
 <li><b>PluginParentChild</b><br/>
 An example plugin demonstrating how to do "parent-child" functions in your plugin.</li>
+<li><b>PluginSectionVariables</b><br/>
+An example plugin demonstrating how to implement functions to use as seciton variables in your plugin.</li>
 </ul>
 
 <p>To create a plugin, the simplest approach is to make a copy of and rename the PluginEmpty example folder and files.  Use GuidGen.exe from Visual Studio with <em>Format 4</em> to generate a new GUID  and add this and other appropriate changes to the .vcxproj or .csproj files. Open either <b>SDK-CPP.sln</b> (C++) or <b>SDK-CS.sln</b> (C#) in Visual Studio, add your new plugin project to the solution, develop your code in this template and build your plugin.  Be sure that you use the <em>Solution Configuration</em> and <em>Solution Platforms</em> fields and build both x32 and x64 architecture release versions of your plugin .dll before you distribute it.</p>
@@ -74,8 +76,8 @@ An example plugin demonstrating how to do "parent-child" functions in your plugi
 <h2 id="APIDocumentation">Plugin API Documentation</h2>
 
 <ul>
-<li><a href="https://github.com/rainmeter/rainmeter-plugin-sdk/wiki/C---plugin-API">Documentation for C++</a><br/><br/></li>
-<li><a href="https://github.com/rainmeter/rainmeter-plugin-sdk/wiki/C%23-plugin-API">Documentation for C#</a><br/><br/></li>
+<li>Documentation for C++ plugins can be found <a href="!Plugin/C++-Reference/">here</a> and the API <a href="!Plugin/C++-Reference/">here</a><br/><br/></li>
+<li>Documentation for C# plugins can be found <a href="!Plugin/CSharp-Reference/">here</a> and the API <a href="!Plugin/CSharp-Reference/">here</a><br/><br/></li>
 </ul>
 
 <h2 id="SendMessage">Using SendMessage with External Applications</h2>

--- a/source/manual-beta/variables/section-variables.html
+++ b/source/manual-beta/variables/section-variables.html
@@ -3,7 +3,7 @@ layout: manual-beta
 permalink: manual-beta/variables/section-variables/
 title: 'Section Variables'
 ---
-<p><a href="!measures/">Measures</a> and <a href="!meters/">meters</a> can be referenced as <a href="!variables/">variables</a>. These are called <b>section variables</b>, and they can provide several kinds of information about the meter or measure.</p>
+<p><a href="!measures/">Measures</a> and <a href="!meters/">meters</a> can be referenced as <a href="!variables/">variables</a>. These are called <b>section variables</b>, and they can provide several kinds of information about the meter or measure. Lua scripts can also be called inline and most will work right out of the box and plugins can also add support but will be on a more case by case basis</p>
 
 <h2 id="Usage">Usage</h2>
 
@@ -81,7 +81,7 @@ title: 'Section Variables'
 	<dd>
 		<p>The measure's string value will be treated as a <a href="!skins/option-types/#RegExp">PCRE Regular Expression</a> pattern, and all regular expression <a href="http://www.regular-expressions.info/characters.html">reserved characters</a>, which are <code>.</code><code>^</code><code>$</code><code>*</code><code>+</code><code>?</code><code>(</code><code>)</code><code>[</code><code>{</code><code>\</code><code>|</code>, will be "escaped" with <code>\</code></a>.</p>
 	</dd>
-	
+
 	<dt id="EncodeURL"><code>:EncodeURL</code><small>Example: <code>[MeasureName:EncodeURL]</code></small></dt>
 	<dd>
 		<p>The measure's string value will be <a href="http://www.blooberry.com/indexdot/html/topics/urlencoding.htm">URL-Encoded</a>.</p>

--- a/themes/rainmeter-docs/layout/developers.ejs
+++ b/themes/rainmeter-docs/layout/developers.ejs
@@ -4,9 +4,16 @@ base_title: 'Developers'
 base_nav: |
 	<h1>Contents</h1>
 	<ul>
-	<li><a href="/developers/#ProjectSourceCode">Project Source Code</a>
-	<li><a href="/developers/#CreatePlugin">Creating Rainmeter Plugins</a>
-	<li><a href="/developers/#SendMessage">SendMessage Examples</a>
+	<li><a href="!Plugin/Basics/">Anatomy of a Plugin</a>
+	<li><a href="!Plugin/C++-Reference/">C++ Overview</a>
+		<ul>
+		<li><a href="!Plugin/C++-Reference/API-Reference/">C++ API Reference</a>
+		</ul>
+	<li><a href="!Plugin/CSharp-Reference/">C# Overview</a>
+		<ul>
+		<li><a href="!Plugin/CSharp-Reference/API-Reference/">C# API Reference</a>
+		</ul>
+	<li><a href="!Plugin/Best-Practices/">Best Practices</a>
 	</ul>
 
 	<h1>More</h1>


### PR DESCRIPTION
As discussed in the IRC now it will no longer be hosted separately from the rest of the
documentation.
Both versions of the documentation have also been updated to bring them further inline with the built in summaries that ship with the SDK. Also added two new pages which should make it easier for new folks to get into making plugins.