### PR TITLE
Fixed typo

### DIFF
--- a/source/manual/getting-started/using-rainmeter.html
+++ b/source/manual/getting-started/using-rainmeter.html
@@ -23,7 +23,7 @@ title: 'Using Rainmeter'
 
 	<blockquote><p><i>Some skins may assign some other action to right-clicking on the skin. In this case, you can still override this action and open the context menu by holding down the <code>Ctrl</code> key when you right-click.</i></p></blockquote>
 
-<p>All skins have the same basic context menu items that you can see in the screenshot on the right. Some skins may have <a href="!skins/rainmeter-section/#Context">custom items</a> to their context menus, but these these will not replace the basic items. Instead, both types of items will appear alongside each other.</p>
+<p>All skins have the same basic context menu items that you can see in the screenshot on the right. Some skins may have <a href="!skins/rainmeter-section/#Context">custom items</a> to their context menus, but these will not replace the basic items. Instead, both types of items will appear alongside each other.</p>
 
 <h3 id="LoadingUnloading">Loading and Unloading</h3>
 


### PR DESCRIPTION
There were two 'there' written under Context Menu. Removed that