### PR TITLE
Added REG_BINARY on the list

### DIFF
--- a/source/manual/measures/registry.html
+++ b/source/manual/measures/registry.html
@@ -41,6 +41,7 @@ title: 'Registry measure'
 			<li><code>REG_MULTI_SZ</code> (string): A series of strings separated by a null character. Rainmeter will convert any null separators to a <a href="!variables/built-in-variables/#CRLF">newline character</a>.</li>
 			<li><code>REG_DWORD</code> (number): Represents a 32-bit unsigned integer.</li>
 			<li><code>REG_QWORD</code> (number): Represents a 64-bit unsigned integer.</li>
+			<li><code>REG_BINARY</code> (string): Binary data in any form.</li>
 			</p>
 	</dd>
 </dl>


### PR DESCRIPTION
[February 11, 2021](https://docs.rainmeter.net/history/#r3433) - Revision 3433
Registry measure: Added support for value type REG_BINARY for registry keys.

I feel more explanation is needed in the following sentence. Please let me know , if I need to fix something.
```html
<li><code>REG_BINARY</code> (string): Binary data in any form.</li>
```