### PR TITLE
Fixed broken link - Exif

### DIFF
--- a/source/manual/meters/general-options/image-options.html
+++ b/source/manual/meters/general-options/image-options.html
@@ -73,7 +73,7 @@ title: 'General Image Options'
 
 	<dt id="UseExifOrientation"><code>UseExifOrientation</code> <small>Default: <code>0</code></small></dt>
 	<dd>
-		<p>If set to <code>1</code>, the image is rotated based on the <a href="https://www.impulseadventure.com/photo/exif-orientation.html">EXIF</a> data encoded in the image by a camera.</p>
+		<p>If set to <code>1</code>, the image is rotated based on the <a href="https://en.wikipedia.org/wiki/Exif">EXIF</a> data encoded in the image by a camera.</p>
 	</dd>
 
 	<dt id="ColorMatrix"><code>ColorMatrix<em>N</em></code></dt>


### PR DESCRIPTION
Fixed broken link https://docs.rainmeter.net/manual/meters/general-options/image-options/#UseExifOrientation
Old: `https://www.impulseadventure.com/photo/exif-orientation.html`
New: `https://en.wikipedia.org/wiki/Exif`

[Reported](https://forum.rainmeter.net/viewtopic.php?t=35992&start=60#p212136) by Jeff
