### PR TITLE
Fix typo and example in measure time.html

### DIFF
--- a/source/manual/measures/time.html
+++ b/source/manual/measures/time.html
@@ -149,7 +149,7 @@ title: 'Time measure'
 		<code>Format=%#c</code><br/>
 		The result in a String meter will be the language and format representation appropriate for the system the skin is running on.</p>
 
-		<b>Note:</b> While any Format string desired can be used, the codes like <code>%#c</code> that return long or short representations of the date and/or time for the system locale or the locale defined by TimeStampLocale or FormatLocal are particularly useful for easily changing between locale values from the "input" to the "output". Not only will it use the language defined by the locale, but also with the appropriate order, structure and punctuation.</p>
+		<b>Note:</b> While any Format string desired can be used, the codes like <code>%#c</code> that return long or short representations of the date and/or time for the system locale or the locale defined by TimeStampLocale or FormatLocale are particularly useful for easily changing between locale values from the "input" to the "output". Not only will it use the language defined by the locale, but also with the appropriate order, structure and punctuation.</p>
 
 	</dd>
 
@@ -195,7 +195,7 @@ title: 'Time measure'
 <li><code>%R</code>: 24-hour HH:MM clock time. (e.g. "22:55")</li>
 <li><code>%S</code>: Second as number (00 - 59).</li>
 <li><code>%t</code>: Horizontal-tab character. (\t)</li>
-<li><code>%T</code>: ISO 8601 HH:MM:SS time format, equivalent to %H:%M:%S. (e.g. 22:55)</li>
+<li><code>%T</code>: ISO 8601 HH:MM:SS time format, equivalent to %H:%M:%S. (e.g. "22:55:03")</li>
 <li><code>%u</code>: ISO 8601 weekday as number with Monday as first day of week. (1 - 7)</li>
 <li><code>%U</code>: Week of year number, with the first Sunday as first day of week one. (00 - 53)</li>
 <li><code>%V</code>: ISO 8601 week of year number (01 - 53)</li>


### PR DESCRIPTION
* typo from `FormatLocal` to `FormatLocale`
* example of `%T` from `22:55` to `"22:55:03"`

Rainmeter Forum Yincognito's [post](https://forum.rainmeter.net/viewtopic.php?p=214007#p214007)
Yincognito mentioned about `%c` (e.g. "Sat Dec 26 22:55:03 2015"), but it is same order in some environment. (depend on the locale)

![TimeMeasure Format 01](https://user-images.githubusercontent.com/58021194/232163215-b971b9f7-c92b-4da9-b42d-9bc899111cc9.png)
