### PR TITLE
A few fixes on some pages and information on Disabled/Paused on plugins

### DIFF
--- a/source/css/rainmeter.css
+++ b/source/css/rainmeter.css
@@ -883,6 +883,15 @@ table#quickjump td {
   -webkit-animation-delay: 12s;
   animation-delay: 12s;
 }
+.floatingIcons li:nth-child(11) {
+  left: 70%;
+  width: 14rem;
+  height: 14rem;
+  -webkit-animation: animation2 22s infinite;
+  animation: animation2 22s infinite;
+  -webkit-animation-delay: 10s;
+  animation-delay: 10s;
+}
 @-webkit-keyframes animation1 {
   0% {
     -webkit-transform: translateY(0);

--- a/source/developers/index.html
+++ b/source/developers/index.html
@@ -69,6 +69,10 @@ An example plugin that returns the Windows system version to a skin.</li>
 An example plugin demonstrating how to do "parent-child" functions in your plugin.</li>
 <li><b>PluginSectionVariables</b><br/>
 An example plugin demonstrating how to implement functions to use as section variables in your plugin.</li>
+<li><b>PluginRmExecute</b><br/>
+An example plugin demonstrating how to make an option be read and execute the bang within.</li>
+<li><b>PluginDataHandling</b><br/>
+An example plugin demonstrating how to keep data across functions calls and also storing data in the <a href="/manual/settings/#RainmeterData">Rainmeter.data</a> file for presistant access across skin reloads and even measures.</li>
 </ul>
 
 <p>To create a plugin, the simplest approach is to make a copy of and rename the PluginEmpty example folder and files.  Use GuidGen.exe from Visual Studio with <em>Format 4</em> to generate a new GUID  and add this and other appropriate changes to the .vcxproj or .csproj files. Open either <b>SDK-CPP.sln</b> (C++) or <b>SDK-CS.sln</b> (C#) in Visual Studio, add your new plugin project to the solution, develop your code in this template and build your plugin.  Be sure that you use the <em>Solution Configuration</em> and <em>Solution Platforms</em> fields and build both x32 and x64 architecture release versions of your plugin .dll before you distribute it.</p>

--- a/source/developers/plugins/guidelines.html
+++ b/source/developers/plugins/guidelines.html
@@ -62,4 +62,4 @@ title: 'Plugin Guidelines'
 <h3 id="DisabledPaused">What do the <code>Disabled</code> and <code>Paused</code> options do in a plugin?</h3>
 <p>If either are set to <code>1</code>, they only affects the execution of the <a href="!plugin/cpp/#Update">Update</a> function. Rainmeter will still call the Initialize, Reload and Finalize functions.</p>
 <p>Ideally, plugins should do the bulk of the "work" in the Update function to minimize any processing and to take advantage of what the user expects when the options (and bangs for set options) are used.</p>
-<p>Avoid relying on the Update function to control threads if multi-threaidng.</p>
+<p>Avoid relying on the Update function to control threads if multi-threading.</p>

--- a/source/developers/plugins/guidelines.html
+++ b/source/developers/plugins/guidelines.html
@@ -58,3 +58,8 @@ title: 'Plugin Guidelines'
 <p>When making C# plugins you may notice references to IntPtr's and <a href="https://docs.microsoft.com/dotnet/framework/interop/interop-marshaling">Marshal</a> functions. Since Rainmeter is written in C++, variables are encoded differently, but don't be intimidated by them.</p>
 <p>An <a href="https://docs.microsoft.com/dotnet/api/system.intptr">IntPtr</a> is basically an integer that represents a <a href="https://en.wikipedia.org/wiki/Pointer_(computer_programming)">pointer</a> to some data, which is why you must deallocate data in finalize as well as recast it in every function. Also since strings are formatted differently in C++, you should pass your string to <a href="https://docs.microsoft.com/dotnet/api/system.runtime.interopservices.marshal.stringtohglobaluni">Marshal.StringToHGlobalUni</a> before returning it in <a href="!plugin/csharp/#GetString">GetString</a> or <a href="!plugin/csharp/#Custom">custom section variables</a>.</p>
 <p>Also the MarshalAs in ExecuteBang and SectionVariable examples just makes sure that you get a C# style string or string array out of the box.</p>
+
+<h3 id="DisabledPaused">What do the <code>Disabled</code> and <code>Paused</code> options do in a plugin?</h3>
+<p>If either are set to <code>1</code>, they only affects the execution of the <a href="!plugin/cpp/#Update">Update</a> function. Rainmeter will still call the Initialize, Reload and Finalize functions.</p>
+<p>Ideally, plugins should do the bulk of the "work" in the Update function to minimize any processing and to take advantage of what the user expects when the options (and bangs for set options) are used.</p>
+<p>Avoid relying on the Update function to control threads if multi-threaidng.</p>

--- a/source/developers/plugins/plugin-anatomy.html
+++ b/source/developers/plugins/plugin-anatomy.html
@@ -38,6 +38,10 @@ title: 'Anatomy of a Plugin'
     Incredibly useful for interacting with your plugin. Media playback plugins are a good example of using this, so then a skin could have a button to pause the music on command.
   </p>
   <p>
+    <h3 id="IntPtr"><i>IntPtr</i> (Optional)</h3>
+    Bridge between managed and unmanaged code, allowing retrieval of a string from a managed object and making it accessible as a null-terminated Unicode string in the unmanaged environment.
+  </p>
+  <p>
     <h3 id="SectionVariables"><i>SectionVariables</i> (Optional)</h3>
     Called whenever a section variables is used ex. <code>[pluginMeasure:func(arg1, arg2)]</code>.<br>
     While similar to ExecuteBang this has the added nicety of being able to return a value. Note that Rainmeter prevents these from being called before Initialization so data will be setup.

--- a/source/developers/plugins/plugin-anatomy.html
+++ b/source/developers/plugins/plugin-anatomy.html
@@ -20,7 +20,8 @@ title: 'Anatomy of a Plugin'
   <p>
     <h3 id="Update"><i>Update</i></h3>
     Called on every update cycle of the measure.<br>
-    Return the value you want to use as the number value of the measure here. You should do anything that requires being run regularly here
+    Return the value you want to use as the number value of the measure here. You should do anything that requires being run regularly here.<br>
+    This is the only function affected by the <code>Disabled</code> and <code>Paused</code> options.
   </p>
   <p>
     <h3 id="Finalize"><i>Finalize</i></h3>

--- a/source/developers/plugins/plugin-anatomy.html
+++ b/source/developers/plugins/plugin-anatomy.html
@@ -10,7 +10,7 @@ title: 'Anatomy of a Plugin'
   <p>
     <h3 id="Initialize"><i>Initialize</i></h3>
     Called before anything on measures first load.<br>
-    Initialize your object you want to store in the data pointer here, as well as any other setup your plugin will need to do. You should also store the measure refernce here if you are going to make use of it outside Initialize or Reload.
+    Initialize your object you want to store in the data pointer here, as well as any other setup your plugin will need to do. You should also store the measure reference here if you are going to make use of it outside Initialize or Reload.
   </p>
   <p>
     <h3 id="Reload"><i>Reload</i></h3>

--- a/source/developers/plugins/plugin-anatomy.html
+++ b/source/developers/plugins/plugin-anatomy.html
@@ -29,7 +29,7 @@ title: 'Anatomy of a Plugin'
   </p>
   <p>
     <h3 id="GetString"><i>GetString</i> (Optional)</h3>
-    Called as the string value of the measure is used in any meters or measures.<br>
+    Called as the string value of the measure is used in any meters (e.g. <code>MeasureName</code>) or measures, and "on-demand" in the <a href="/manual/user-interface/about/#SkinsTab">User Interface</a>.<br>
     Return the value you want to use as the string value of the measure here. You should do absolutely no processing here as it is possible to have this called multiple times an update. Instead calculate any values in update and just return them here.
   </p>
   <p>

--- a/source/manual/getting-started/index.html
+++ b/source/manual/getting-started/index.html
@@ -60,6 +60,7 @@ subtitle: 'An introduction to Rainmeter.'
 <p>In short, you cannot usually download and apply someone else's amazing desktop transformation in one click. Most customizers are courteous enough to provide links to the myriad programs, plugins, icons, wallpapers and other materials that they have used.</p>
 
 <div class="docs-pagination">
-  <hr class="mt-4"/>
+	<hr class="mt-4"/>
+	<p class="float-left mt-2">Navigate through the <em>Getting Started</em> guide using the buttons here.</p>
   <a class="btn btn-outline-primary float-right" href="!getting-started/setting-up/">Continue to: Setting Up &raquo;</a>
 </div>

--- a/source/manual/getting-started/index.html
+++ b/source/manual/getting-started/index.html
@@ -25,7 +25,7 @@ subtitle: 'An introduction to Rainmeter.'
 
 <p>Skins can interact with other skins and applications using special commands, called <a href="!bangs/">bangs</a>, and they can be customized by changing short lines of text, called <a href="!variables/">variables</a>. All of these things are made possible by Rainmeter's unique code language, which allows a skin to access functions and resources built into the Rainmeter application. Every skin's code is completely open, and can be tweaked, modified or even completely rewritten using any text editing software.</p>
 
-<h2>How much technical skill do I need to use Rainmeter?</h2>
+<h2 id="HowMuchTechnicalSkill">How much technical skill do I need to use Rainmeter?</h2>
 
 <p>If you only want to <b>download</b> skins from the Internet and <b>use</b> them as-is, then the answer is "none." Rainmeter provides a basic <a href="!user-interface/">user interface</a> for managing your <a href="!user-interface/manage/#SkinsList">library</a> of skins, saving and restoring <a href="!user-interface/manage/#LayoutsTab">layouts</a>, and changing basic <a href="!user-interface/manage/#SkinSettings">settings</a> such as a skin's location, transparency, and "always on top" behavior.</p>
 

--- a/source/manual/measures/nowplaying.html
+++ b/source/manual/measures/nowplaying.html
@@ -141,9 +141,10 @@ Measure=NowPlaying
 <p>The following players are partially supported. Only some features will work.</p>
 
 <ul class="spaced">
+	<!--
 	<li><b>Spotify</b>: <code>PlayerName=Spotify</code><br>
 	Partially supported. Only the types <code>Artist</code>, <code>Title</code> and the bangs <code>Play</code>, <code>PlayPause</code>, <code>Stop</code>, <code>Next</code>, and <code>Previous</code> are available.</li>
-
+	-->
 	<li><b>Last.fm Client</b>, <b>TTPlayer</b>, <b>OpenPandora</b>, <b>Zune</b>: <code>PlayerName=WLM</code><br>
 	Partially supported. Even in the best case, only the types <code>Title</code>, <code>Artist</code>, <code>Album</code> and the bangs <code>Play</code>, <code>Pause</code>, <code>PlayPause</code>, <code>Next</code>, <code>Previous</code>, <code>Stop</code> are supported.</li>
 </ul>

--- a/source/manual/meters/general-options/image-options.html
+++ b/source/manual/meters/general-options/image-options.html
@@ -5,7 +5,7 @@ title: 'General Image Options'
 ---
 <p>Options available for use with all images. These options are to modify the display of an image file, and do not work with square/rectangle Image meters created entirely with SolidColor / SolidColor2, or with any shape created by a Shape meter.</p>
 
-<p><b>Note:</b>Supported image formats are <b>.png</b>, <b>.jpg</b>, <b>.bmp</b>, <b>.gif</b> (no <a href="/tips/animated-gif-files">animation</a> supported), <b>.tif</b>, <b>.webP</b> and <b>.ico</b>. If no file extension is included, <b>.png</b> is assumed.</p>
+<p><b>Note:</b> Supported image formats are <b>.png</b>, <b>.jpg</b>, <b>.bmp</b>, <b>.gif</b> (no <a href="/tips/animated-gif-files">animation</a> supported), <b>.tif</b>, <b>.webP</b> and <b>.ico</b>. If no file extension is included, <b>.png</b> is assumed.</p>
 
 <h2>Options</h2>
 <dl>

--- a/source/manual/meters/image.html
+++ b/source/manual/meters/image.html
@@ -5,7 +5,7 @@ title: 'Image Meter'
 ---
 <p><code>Meter=Image</code> displays either an image defined by a measure value, or any named image. If <code>W</code> and/or <code>H</code> are included in the meter options, the image will be scaled to fit the meter size.</p>
 
-<p><b>Note:</b>Supported image formats are <b>.png</b>, <b>.jpg</b>, <b>.bmp</b>, <b>.gif</b> (no <a href="/tips/animated-gif-files">animation</a> supported), <b>.tif</b>, <b>.webP</b> and <b>.ico</b>. If no file extension is included, <b>.png</b> is assumed.</p>
+<p><b>Note:</b> Supported image formats are <b>.png</b>, <b>.jpg</b>, <b>.bmp</b>, <b>.gif</b> (no <a href="/tips/animated-gif-files">animation</a> supported), <b>.tif</b>, <b>.webP</b> and <b>.ico</b>. If no file extension is included, <b>.png</b> is assumed.</p>
 
 <h2>Options</h2>
 <dl>

--- a/source/manual/meters/shape/index.html
+++ b/source/manual/meters/shape/index.html
@@ -5,8 +5,9 @@ title: 'Shape meter'
 ---
 <p><code>Meter=Shape</code> is used to create one or more <a href="https://en.wikipedia.org/wiki/Vector_graphics">vector graphic</a> shapes.</p>
 
-<div style="display:inline-block">
-<img src="!img/shapes/Shapes.png"/>
+<div class="exampleprev">
+	<a href="!img/shapes/Shapes.png" data-fancybox><img src="!img/shapes/Shapes.png"></a>
+	<p>An example skin demonstrating different shape types made using the Shape meter.</p>
 </div>
 
 <h2>Quick Jump</h2>

--- a/source/manual/meters/shape/index.html
+++ b/source/manual/meters/shape/index.html
@@ -748,5 +748,5 @@ MyModifiers1=Fill Color 191,237,239,255 | StrokeWidth 0
 
 <div class="exampleprev">
 	<a href="!img/example-meters/ExampleMeterShape.jpg" data-fancybox><img src="!img/example-meters/ExampleMeterShape.jpg"></a>
-	<p>An example skin demonstrating the Shape meter.</p>
+	<p>An example skin demonstrating various ways to manipulate the Rectangle shape type.</p>
 </div>


### PR DESCRIPTION
Hello! I hope the commit titles are descriptive enough for what I commited :P

I made a few fixes related to mistakes I did in my last pull request and also added some new stuff.

I also added some info related to how Disabled/Paused work, as I asked (and got info) on the forums. I went with

> ### What do the `Disabled` and `Paused` options do in a plugin?
> If either are set to `1`, they only affects the execution of the Update function. Rainmeter will still call the Initialize, Reload and Finalize functions.
> Ideally, plugins should do the bulk of the "work" in the Update function to minimize any processing and to take advantage of what the user expects when the options (and bangs for set options) are used.
> Avoid relying on the Update function to control threads if multi-threading.

 on the Guidelines page and

> This is the only function affected by the `Disabled` and `Paused` options.

on the Anatomy page, which I hope signals enough that only Update gets stopped by those options.

If one of the commits isn't consistent (like 317b051a2d9ffad27b973af488c682d82958ee6d because it dosen't touch LPCWSTR on C++) you can not add them, it's okay.