### PR TITLE
Add ¶ support and other changes

### DIFF
--- a/source/css/rainmeter.css
+++ b/source/css/rainmeter.css
@@ -554,6 +554,32 @@ pre code {
   color: #036eb9;
 }
 
+/* Docs Ampersend Hyperlink */
+.heading-anchor {
+  visibility: hidden;
+  color: #0058cc;
+  padding: 0.5rem;
+}
+
+h1:hover > .heading-anchor,
+h2:hover > .heading-anchor,
+h3:hover > .heading-anchor,
+h4:hover > .heading-anchor,
+h5:hover > .heading-anchor,
+h6:hover > .heading-anchor,
+dt:hover > .heading-anchor,
+span:hover > .heading-anchor {
+  visibility: visible;
+}
+
+dt .heading-anchor {
+  color: #e09028;
+}
+
+dt:target .heading-anchor {
+  color: #0058cc;
+}
+
 /* Docs index cards */
 
 .docs-index .card {

--- a/source/css/solid.css
+++ b/source/css/solid.css
@@ -16,4 +16,6 @@
 
 .fas,
 .fa-solid {
-  font-weight: 900; }
+  font-weight: 900;
+  padding-left: 0.25rem;
+  padding-right: 0.25rem; }

--- a/source/developers/index.html
+++ b/source/developers/index.html
@@ -86,7 +86,7 @@ An example plugin demonstrating how to keep data across functions calls and also
 
 <h2 id="SendMessage">Using SendMessage with External Applications</h2>
 
-<p>The Rainmeter window message API can be used to query or control Rainmeter from external applications. Documentation for the available queriese, as well as their definitions, can be found <a href="https://github.com/rainmeter/rainmeter/blob/master/Library/RainmeterQuery.h">here</a>.</p>
+<p>The Rainmeter Window Message API can be used to query or control Rainmeter from external applications. Documentation for the available queriese, as well as their definitions, can be found <a href="https://github.com/rainmeter/rainmeter/blob/master/Library/RainmeterQuery.h">here</a>.</p>
 <p> The examples are for C++ and <a href="https://www.autoitscript.com/site/autoit/">AutoIt</a>, but similar functionality is available from any programming platform that can send window messages to running applications.</p>
 <h3>Query</h3>
 

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -72,6 +72,38 @@ function toggleClass(elem, className) {
 	}
 })();
 
+// Add ¶ Heading Anchor to the same tags you can Ctrl+Click on
+// if the HTML element has an id and is one of the tags below
+// Both window.onload and document.onload do the job but i chose the former
+(window.onload = function() {
+	// Tags are copy pasted from the function above
+	var tags = ['dt', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'span'];
+	// This returns all the elements that have the `id` tag 
+	var elementsWithId = document.querySelectorAll("[id]");
+
+	elementsWithId.forEach(function(elementFound) {
+		// We could forEach again, but Array.prototype.includes() already
+		// dose the job, while there are no elements with upercase tags in the docs
+		// this is here just in case.
+		// We also check if the element is in .docs-content, since the Manual text
+		// on the navbar has an id (for some reason).
+		// We also exclude `SomeNote` from the alert boxes.
+		if (tags.includes(elementFound.tagName.toLowerCase()) &&
+			elementFound.closest('.docs-content') &&
+			elementFound.id !== 'SomeNote') {
+			// create an anchor element onto which we just add a href to the id the elementFound has
+			var anchor = document.createElement('a');
+			anchor.href = '#' + elementFound.id;
+			anchor.textContent = '¶';
+			anchor.classList.add('heading-anchor');
+			
+			// adds the ampersend at the end of elementFound
+			// e.g. <h1 id="first">Header<a href=#first>¶</a></h1>
+			elementFound.appendChild(anchor);
+		}
+	})
+});
+
 // Add 'Select all' and 'Download' buttons to <pre> blocks.
 (function() {
 	var divs = document.getElementsByClassName('highlight');

--- a/source/manual/bangs.html
+++ b/source/manual/bangs.html
@@ -21,7 +21,7 @@ title: 'Bangs'
 	<p>Many bangs have a <code>Config</code> parameter. Unless otherwise specified, valid values are the <a href="!skins/#Config">config name</a> of a currently loaded skin to be acted upon or <code>*</code> (asterisk) to act on all currently loaded skins. When optional and not supplied, the parameter defaults to the current config. If executing a bang with a "config" parameter from the Windows command line, the parameter is always required.</p>
 </div>
 
-<h3>Command Line Arguments</h3>
+<h3 id="CommandLineArguments">Command Line Arguments</h3>
 
 <p>Bangs can also be used from the Windows command line as a parameter to the Rainmeter.exe executable. Examples:</p>
 

--- a/source/manual/bangs.html
+++ b/source/manual/bangs.html
@@ -29,7 +29,13 @@ title: 'Bangs'
 	<li><code>"C:\Program Files\Rainmeter\Rainmeter.exe" !RefreshApp</code></li>
 	<li><code>"C:\Program Files\Rainmeter\Rainmeter.exe" !SetVariable "textSize" "12" "illustro\Clock"</code></li>
 </ul>
-<p><b>Note:</b> Any variable of any kind, including <a href="manual/variables/built-in-variables/">Built-In Variables</a>, are not executed when calling Rainmeter from the command line. Likewise, the <code>Config</code> parameter is always required in places where it is treated as optional.</p>
+<br>
+<p><b>(For programmers)</b> External Applications can send Bangs using the Skin's HWND and the Windows <i>SendMessage</i> function (<i>winuser.h</i>), see <a href="/developers/#SendMessage">the Rainmeter Window Message API</a>.</p>
+
+<div class="alert alert-info alert-tight" role="alert">
+	<h2 class="alert-heading h5" id="SomeNote"><i class="fa-solid fa-thumbtack"></i> Note:</h2>
+	<p>Any variable of any kind, including <a href="/manual/variables/built-in-variables/">Built-In Variables</a>, are not resolved when calling Rainmeter from the command line. Likewise, the <code>Config</code> parameter is always required in places where it is treated as optional.</p>
+</div>
 
 
 <h2 id="OS">Operating System bangs</h2>

--- a/source/manual/index.html
+++ b/source/manual/index.html
@@ -43,7 +43,10 @@ title: 'Manual'
 
 <hr>
 
+<!--
 <p><b>Note:</b> Most option entries and header text in the manual can be selected with <b>CTRL-Click</b> to add an <b>#anchor</b> to the URL. This makes it easy to link to a specific part of a page. Try it below.</p>
+-->
+<p><b>Note:</b> Most option entries and header text in the manual can be selected by <b>hovering over them</b> and <b>clicking ¶</b> to add an <b>#anchor</b> to the URL. This makes it easy to link to a specific part of a page. Try it below.</p>
 
 <dl>
 	<dt id="SampleOption"><code>SampleOption</code></dt>

--- a/source/manual/plugins/usagemonitor.html
+++ b/source/manual/plugins/usagemonitor.html
@@ -38,16 +38,18 @@ title: 'UsageMonitor plugin'
 	<dd>
 		<p>Alias or "shortcut" for a particular Category and Counter combination. This may optionally be used in place of specific Category and Counter options on the measure.</p>
 		<br/>
-		<p>The currently supported Alias names and what they reference are:</p><br/>
-		<p>Alias=<b>CPU</b><br/>Category: <em>Process</em> | Counter: <em>% Processor Time</em><br/>CPU usage of each process, across all cores, as a percentage of total CPU.</p>
-		<p>Alias=<b>RAM</b><br/>Category: <em>Process</em> | Counter: <em>Working Set - Private</em><br/>Bytes of Private Working Set RAM used by each process.</p>
-		<p>Alias=<b>RAMSHARED</b><br/>Category: <em>Process</em> | Counter: <em>Working Set</em><br/>Bytes of shared Working Set RAM used by each process.</p>		
-		<p>Alias=<b>IO</b><br/>Category: <em>Process</em> | Counter: <em>IO Data Bytes/sec</em><br/>Bytes per second of read and write usage by each process, across all disks.</p>
-		<p>Alias=<b>IOREAD</b><br/>Category: <em>Process</em> | Counter: <em>IO Read Bytes/sec</em><br/>Bytes per second of read usage by each process, across all disks.</p>
-		<p>Alias=<b>IOWRITE</b><br/>Category: <em>Process</em> | Counter: <em>IO Write Bytes/sec</em><br/>Bytes per second of write usage by each process, across all disks.</p>
-		<p>Alias=<b>GPU</b><br/>Category: <em>GPU Engine</em> | Counter: <em>Utilization Percentage</em><br/>Percentage of GPU usage of each process, across all GPU engines.<br/><b>Note:</b> Requires Windows 10 Fall Creators Update or later.</p>
-		<p>Alias=<b>VRAM</b><br/>Category: <em>GPU Process Memory</em> | Counter: <em>Dedicated Usage</em><br/>Bytes of private video RAM usage of each process, across all GPU engines.<br/><b>Note:</b> Requires Windows 10 Fall Creators Update or later.</p>
-		<p>Alias=<b>VRAMSHARED</b><br/>Category: <em>GPU Process Memory</em> | Counter: <em>Shared Usage</em><br/>Bytes of shared video RAM usage of each process, across all GPU engines.<br/><b>Note:</b> Requires Windows 10 Fall Creators Update or later.</p>
+		<p>The currently supported Alias names and what they reference are:</p>
+		<table class="table-striped">
+			<tr><td><p>Alias=<b>CPU</b><br/>Category: <em>Process</em> | Counter: <em>% Processor Time</em><br/>CPU usage of each process, across all cores, as a percentage of total CPU.</p></td></tr>
+			<tr><td><p>Alias=<b>RAM</b><br/>Category: <em>Process</em> | Counter: <em>Working Set - Private</em><br/>Bytes of Private Working Set RAM used by each process.</p></td></tr>
+			<tr><td><p>Alias=<b>RAMSHARED</b><br/>Category: <em>Process</em> | Counter: <em>Working Set</em><br/>Bytes of shared Working Set RAM used by each process.</p></td></tr>
+			<tr><td><p>Alias=<b>IO</b><br/>Category: <em>Process</em> | Counter: <em>IO Data Bytes/sec</em><br/>Bytes per second of read and write usage by each process, across all disks.</p></td></tr>
+			<tr><td><p>Alias=<b>IOREAD</b><br/>Category: <em>Process</em> | Counter: <em>IO Read Bytes/sec</em><br/>Bytes per second of read usage by each process, across all disks.</p></td></tr>
+			<tr><td><p>Alias=<b>IOWRITE</b><br/>Category: <em>Process</em> | Counter: <em>IO Write Bytes/sec</em><br/>Bytes per second of write usage by each process, across all disks.</p></td></tr>
+			<tr><td><p>Alias=<b>GPU</b><br/>Category: <em>GPU Engine</em> | Counter: <em>Utilization Percentage</em><br/>Percentage of GPU usage of each process, across all GPU engines.<br/><b>Note:</b> Requires Windows 10 Fall Creators Update or later.</p></td></tr>
+			<tr><td><p>Alias=<b>VRAM</b><br/>Category: <em>GPU Process Memory</em> | Counter: <em>Dedicated Usage</em><br/>Bytes of private video RAM usage of each process, across all GPU engines.<br/><b>Note:</b> Requires Windows 10 Fall Creators Update or later.</p></td></tr>
+			<tr><td><p>Alias=<b>VRAMSHARED</b><br/>Category: <em>GPU Process Memory</em> | Counter: <em>Shared Usage</em><br/>Bytes of shared video RAM usage of each process, across all GPU engines.<br/><b>Note:</b> Requires Windows 10 Fall Creators Update or later.</p></td></tr>
+		</table><br>
 	</dd>
 
 	<dt id="Category"><code>Category</code><small>Default: <em>None</em></small></dt>

--- a/source/manual/plugins/usagemonitor.html
+++ b/source/manual/plugins/usagemonitor.html
@@ -3,7 +3,7 @@ layout: docs
 permalink: manual/plugins/usagemonitor/
 title: 'UsageMonitor plugin'
 ---
-<p><code>Plugin=UsageMonitor</code> retrieves infromation from the <a href="https://docs.microsoft.com/previous-versions/windows/it-pro/windows-server-2008-r2-and-2008/dd744567(v=ws.10)">Windows Performance Monitor</a>.</p>
+<p><code>Plugin=UsageMonitor</code> retrieves information from the <a href="https://docs.microsoft.com/previous-versions/windows/it-pro/windows-server-2008-r2-and-2008/dd744567(v=ws.10)">Windows Performance Monitor</a>.</p>
 
 <p>The Windows Performance Monitor exposes counters, which monitor various kinds of system metrics in different categories, and tracks their usage. All available counters can be viewed using the Performance Monitor application. To open it, run Perfmon.exe.</p>
 
@@ -19,7 +19,7 @@ title: 'UsageMonitor plugin'
 
 <ul>
 <li><b>Name</b><br/>This will be the specific (case sensitive) text name of a single given instance, and will return the current value for that specific instance of a counter.</li>
-<li><b>Index</b><br/>This will be either <code>Index=0</code>, which will always return the current total of all instances for a given counter, <code>Index=-1</code>, which will always return the current average of all instances for a given counter,or <code>Index=N</code>, which will return the instance at the defined point in a sorted list of all instances, with their values ordered from most to least. So for example, <code>Index=1</code> would return the current value and name of the instance with the highest value for that counter.</li>
+<li><b>Index</b><br/>This will be either <code>Index=0</code>, which will always return the current total of all instances for a given counter, <code>Index=-1</code>, which will always return the current average of all instances for a given counter, or <code>Index=N</code>, which will return the instance at the defined point in a sorted list of all instances, with their values ordered from most to least. So for example, <code>Index=1</code> would return the current value and name of the instance with the highest value for that counter.</li>
 </ul>
 
 <br/>

--- a/source/manual/plugins/windowmessage.html
+++ b/source/manual/plugins/windowmessage.html
@@ -5,6 +5,8 @@ title: 'WindowMessage plugin'
 ---
 <p><code>Plugin=WindowMessagePlugin</code> can be used to send and receive information from other applications. It can send window messages to other applications and show the result. For example, the plugin can be used to control WinAmp or some similar media players.</p>
 
+<p>For handling Rainmeter from External Applications using the <i>SendMessage</i> function (<i>winuser.h</i>), see <a href="/developers/#SendMessage">the Rainmeter Window Message API</a>.</p>
+
 <h2>Options</h2>
 <dl>
 	<dt>General measure options</dt>


### PR DESCRIPTION
**Most important change**
* [Usability: Add support for clicking the ¶ symbol for anchoring sections of the wiki (since phones don't have the CTRL key)](18fc5ecd5529df558f97e5f3a7ca6ea5645d49d6)
I hope the comments and simple code is enough to understand what happens, but after the page loads, it adds the ¶ symbol to every single element that you were able to Ctrl+Click on previously (you can still do that even now), this was done because on mobile there's no way to press CTRL... for obvious reasons.
The color of the symbol changes in dt boxes to make the symbol easier to see.

**The other changes**
* UsageMonitor: Add a table to make the Aliases easier to differenciate
* UsageMonitor: Correct "infromation" and a missing space after comma
* WindowMessagePlugin: Add info about using SendMessage
* Window Message: Capitalize the letters
* Bangs: Add info about using SendMessage for bangs and correct a dead link
* Bangs: Add id for "Command Line Arguments"
* CSS: For the FA icons, add space to the left and right of them, so it dosen't hug the text and corner no more