### PR TITLE
Added Font Weight 350 - Semi Light

### DIFF
--- a/source/manual/meters/string/index.html
+++ b/source/manual/meters/string/index.html
@@ -78,6 +78,7 @@ Text=This is text containing %1 and %2.
 		<b>100</b> - Thin (Hairline)<br/>
 		<b>200</b> - Extra Light (Ultra Light)<br/>
 		<b>300</b> - Light<br/>
+		<b>350</b> - Semi Light<br/>
 		<b>400</b> - Regular (Normal)<br/>
 		<b>500</b> - Medium<br/>
 		<b>600</b> - Semi Bold (Demi Bold)<br/>

--- a/source/manual/meters/string/inline.html
+++ b/source/manual/meters/string/inline.html
@@ -42,6 +42,7 @@ title: 'Inline Options'
 			<b>100</b> - Thin (Hairline)<br/>
 			<b>200</b> - Extra Light (Ultra Light)<br/>
 			<b>300</b> - Light<br/>
+			<b>350</b> - Semi Light<br/>
 			<b>400</b> - Regular (Normal)<br/>
 			<b>500</b> - Medium<br/>
 			<b>600</b> - Semi Bold (Demi Bold)<br/>


### PR DESCRIPTION
> **SemiLight** Specifies a font weight value of 350.  [FontWeights Class](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.text.fontweights#properties)  

The fonts that has **SemiLight** weight on Windows 11. [Windows 11 font list](https://learn.microsoft.com/typography/fonts/windows_11_font_list)  
`Segoe UI Semilight` `Segoe UI Variable Display Semilight` `Segoe UI Variable Small Semilight` `Segoe UI Variable Text Semilight` `Cascadia Code SemiLight` `Cascadia Mono SemiLight` `Leelawadee UI Semilight` `Malgun Gothic Semilight` `Nirmala UI Semilight` `Yu Gothic UI Semilight`