### PR TITLE
FIX: Various fixes

### DIFF
--- a/source/developers/plugins/guidelines.html
+++ b/source/developers/plugins/guidelines.html
@@ -55,9 +55,18 @@ title: 'Plugin Guidelines'
 </p>
 
 <h3 id="Marshalling">C# Marshalling</h3>
-<p>When making C# plugins you may notice references to IntPtr's and <a href="https://learn.microsoft.com/dotnet/framework/interop/interop-marshalling">Marshal</a> functions. Since Rainmeter is written in C++, variables are encoded differently, but don't be intimidated by them.</p>
-<p>An <a href="https://learn.microsoft.com/dotnet/api/system.intptr">IntPtr</a> is basically an integer that represents a <a href="https://en.wikipedia.org/wiki/Pointer_(computer_programming)">pointer</a> to some data, which is why you must deallocate data in finalize as well as recast it in every function. Also since strings are formatted differently in C++, you should pass your string to <a href="https://learn.microsoft.com/dotnet/api/system.runtime.interopservices.marshal.stringtohglobaluni">Marshal.StringToHGlobalUni</a> before returning it in <a href="!plugin/csharp/#GetString">GetString</a> or <a href="!plugin/csharp/#Custom">custom section variables</a>.</p>
-<p>Also the MarshalAs in ExecuteBang and SectionVariable examples just makes sure that you get a C# style string or string array out of the box.</p>
+<p>While inspecting the <a href="https://github.com/rainmeter/rainmeter-plugin-sdk/tree/master/C%23">Rainmeter Plugin SDK C# Examples</a>, as well as checking the <i>Examples</i> on the <a href="!plugin/csharp/">C# Plugin Overview</a> page, you may notice an excessive usage of <i>IntPtr</i>s and <a href="https://learn.microsoft.com/dotnet/framework/interop/interop-marshalling">Marshal</a> namespace functions.</p>
+<p>The <a href="https://github.com/rainmeter/rainmeter-plugin-sdk/blob/master/API/RainmeterAPI.cs">Rainmeter C# API</a> works by invoking methods in unmanaged dynamic-link library (DLL), more specifically in <code>Rainmeter.dll</code>. Due to Rainmeter being written in C++, it expects data styled (data types, encoded strings and variables) in said language.</p>
+<p>Do not be intimidated by any of this. An <i>IntPtr</i> in C# is simply an object which simulates a pointer to C++ style data, which is why you must dealocate data in finalize as well as recast it in every function.</p>
+<p>
+	<ul>
+		<li>When working with Rainmeter specific Data Types (e.g. <code>Measure()</code>), the specific C# object should be allocated to the Garbage Collecter in order to make it a valid object which can be turned into an IntPtr. (e.g. <code>GCHandle.ToIntPtr(GCHandle.Alloc(measure))</code>).</li>
+		<li>Since strings are formatted differently in C++, you should pass your string to <a href="https://learn.microsoft.com/dotnet/api/system.runtime.interopservices.marshal.stringtohglobaluni">Marshal.StringToHGlobalUni</a> before returning it in <a href="!plugin/csharp/#GetString">GetString</a> or <a href="!plugin/csharp/#Custom">custom section variables</a>.</li>
+		<li>Aditionally, the MarshalAs in ExecuteBang and SectionVariable examples just makes sure that you get a C# style string or string array out of the box.</li>
+	</ul>
+</p>
+
+
 
 <h3 id="DisabledPaused">What do the <code>Disabled</code> and <code>Paused</code> options do in a plugin?</h3>
 <p>If either are set to <code>1</code>, they only affects the execution of the <a href="!plugin/cpp/#Update">Update</a> function. Rainmeter will still call the Initialize, Reload and Finalize functions.</p>

--- a/themes/rainmeter-docs/layout/_partial/footer.ejs
+++ b/themes/rainmeter-docs/layout/_partial/footer.ejs
@@ -2,7 +2,7 @@
   <div class="container">
     <div class="row">
       <div class="col-6">© 2026 Rainmeter Team</div>
-      <div class="col-6 text-md-right"><button id="theme-toggle" type="button" aria-label="Switch to dark theme" aria-pressed="false"><i class="fas fa-sun" aria-hidden="true"></i> <span>Light theme</span></button></div>
+      <div class="col-6 text-right"><button id="theme-toggle" type="button" aria-label="Switch to dark theme" aria-pressed="false"><i class="fas fa-sun" aria-hidden="true"></i> <span>Light theme</span></button></div>
     </div>
   </div>
 </footer>

--- a/themes/rainmeter-docs/layout/_partial/navigation.ejs
+++ b/themes/rainmeter-docs/layout/_partial/navigation.ejs
@@ -1,6 +1,6 @@
 <nav id="navbar" class="navbar navbar-expand-lg navbar-dark">
 	<div class="container">
-		<a class="navbar-brand" href="<%- config.url %>"><img src="/img/logo_nav.svg" alt=""></a>
+		<a class="navbar-brand" href="<%- config.url %>"><img src="/img/logo_nav.png" alt=""></a>
 		<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainNavigation" aria-controls="mainNavigation" aria-expanded="false" aria-label="Toggle navigation">
 			<span class="navbar-toggler-icon"></span>
 		</button>


### PR DESCRIPTION
Hey hey, I made a few changes
* The theme toggle at the bottom of the page now sits aligned to the right, previously it didn't because it expected to do said behavior in a markdown field which was impossible. Example pic below for how it looked on mobile.

<img width="2208" height="432" alt="Screenshot_2026-07-20_18-34-23" src="https://github.com/user-attachments/assets/1d9045b3-1d57-445e-a3e7-c267d57c25e4" />

* Return the Rainmeter logo from SVG back to the PNG (EDIT: I got sniped while making this commit.)
* Rewrote some parts of the C# Marhsalling section to add more info.
  * Originally, the text was:
> When making C# plugins you may notice references to IntPtr's and [Marshal](https://learn.microsoft.com/dotnet/framework/interop/interop-marshalling) functions. Since Rainmeter is written in C++, variables are encoded differently, but don't be intimidated by them.
> 
> An [IntPtr](https://learn.microsoft.com/dotnet/api/system.intptr) is basically an integer that represents a [pointer](https://en.wikipedia.org/wiki/Pointer_(computer_programming)) to some data, which is why you must deallocate data in finalize as well as recast it in every function. Also since strings are formatted differently in C++, you should pass your string to [Marshal.StringToHGlobalUni](https://learn.microsoft.com/dotnet/api/system.runtime.interopservices.marshal.stringtohglobaluni) before returning it in [GetString](https://docs.rainmeter.net/developers/plugin/csharp/#GetString) or [custom section variables](https://docs.rainmeter.net/developers/plugin/csharp/#Custom).
> 
> Also the MarshalAs in ExecuteBang and SectionVariable examples just makes sure that you get a C# style string or string array out of the box.

  * The text has been changed to say:

> While inspecting the [Rainmeter Plugin SDK C# Examples](https://github.com/rainmeter/rainmeter-plugin-sdk/tree/master/C%23), as well as checking the Examples on the [C# Plugin Overview](http://localhost:4000/developers/plugin/csharp/) page, you may notice an excessive usage of IntPtrs and [Marshal](https://learn.microsoft.com/dotnet/framework/interop/interop-marshalling) namespace functions.
> 
> The [Rainmeter C# API](https://github.com/rainmeter/rainmeter-plugin-sdk/blob/master/API/RainmeterAPI.cs) works by invoking methods in unmanaged dynamic-link library (DLL), more specifically in Rainmeter.dll. Due to Rainmeter being written in C++, it expects data styled (data types, encoded strings and variables) in said language.
> 
> Do not be intimidated by any of this. An IntPtr in C# is simply an object which simulates a pointer to C++ style data, which is why you must dealocate data in finalize as well as recast it in every function.
> 
>    * When working with Rainmeter specific Data Types (e.g. Measure()), the specific C# object should be allocated to the Garbage Collecter in order to make it a valid object which can be turned into an IntPtr. (e.g. GCHandle.ToIntPtr(GCHandle.Alloc(measure))).
>    * Since strings are formatted differently in C++, you should pass your string to [Marshal.StringToHGlobalUni](https://learn.microsoft.com/dotnet/api/system.runtime.interopservices.marshal.stringtohglobaluni) before returning it in [GetString](http://localhost:4000/developers/plugin/csharp/#GetString) or [custom section variables](http://localhost:4000/developers/plugin/csharp/#Custom).
>    * Aditionally, the MarshalAs in ExecuteBang and SectionVariable examples just makes sure that you get a C# style string or string array out of the box.