### PR TITLE
CSS: Tweak Dark Theme Colors

### DIFF
--- a/source/css/rainmeter.css
+++ b/source/css/rainmeter.css
@@ -60,29 +60,29 @@
 
 :root[data-theme="dark"] {
   --color-scheme: dark;
-  --color-page: #090d14;
-  --color-search-bg: var(--color-page);
-  --color-surface: #0d141f;
-  --color-surface-alt: #151d2a;
+  --color-page: #212121;
+  --color-search-bg: #343434;
+  --color-surface: #2a2a2a;
+  --color-surface-alt: #29292b;
   --color-surface-muted: rgba(255, 255, 255, .03);
-  --color-text: #abb8cc;
-  --color-text-muted: #97a6ba;
-  --color-heading: #7ab7ff;
-  --color-heading-subtle: #d4deec;
+  --color-text: #aab5c7;
+  --color-text-muted: #959c9c;
+  --color-heading: #93d4ea;
+  --color-heading-subtle: #b3c5d3;
   --color-link: #66a6ff;
   --color-link-hover: #a8ccff;
-  --color-navbar-bg: #081d39;
+  --color-navbar-bg: #111947;
   --color-anchor: #6bd982;
   --color-dt-anchor: #b8ffc1;
-  --color-border: rgba(255, 255, 255, .12);
+  --color-border: rgba(47, 47, 47, .12);
   --color-border-soft: rgba(255, 255, 255, .07);
   --color-code-button-bg: var(--color-page);
-  --color-code-block-bg: rgba(255, 255, 255, .025);
+  --color-code-block-bg: rgba(21, 27, 35, .35);
   --color-code: #d7defd;
-  --color-dt-bg: #103957;
+  --color-dt-bg: #11274e;
   --color-dt-sub-bg: #1d2d40;
   --color-dt-target-bg: #784914;
-  --color-footer-bg: #070a10;
+  --color-footer-bg: #29292b;
   --color-footer-text: rgba(255, 255, 255, .35);
   --color-footer-link: rgba(255, 255, 255, .55);
   --color-syntax-text: #fff;
@@ -251,12 +251,12 @@ blockquote {
 }
 :root[data-theme="dark"] .alert-info {
   color: #b8e8f0;
-  background-color: #081a22;
+  background-color: #183032;
   border-color: #173947;
 }
 :root[data-theme="dark"] .alert-warning {
   color: #f3d8a0;
-  background-color: #201707;
+  background-color: #322b0f;
   border-color: #493411;
 }
 :root[data-theme="dark"] .alert-danger {
@@ -270,7 +270,7 @@ blockquote {
   border-color: #1e452b;
 }
 :root[data-theme="dark"] .alert code {
-  background-color: rgba(255, 255, 255, .08);
+  background-color: rgba(255, 255, 255, .15);
   border-color: rgba(255, 255, 255, .14);
 }
 


### PR DESCRIPTION
Now, normally for the dark theme we should have been inspired by Bootstrap, since the documentation is built on top of it and uses components from it extensively (e.g. dt, alerts, navbar etc.).

Sadly, I am not in the "normally" camp, so I got inspired to switch the colors based on the colors from the automatic Night theme from Samsung Internet (which is like saying you got inspiration from a mud pit outside).

Below are a set of pictures for how the change will look. I have been unable to tweak the border of the dt shapes to be more visible like in the original.

Current is LEFT, my PR is RIGHT

<img width="3840" height="1936" alt="Screenshot_2026-07-20_18-26-47" src="https://github.com/user-attachments/assets/c562176b-8ed2-4e2d-a23d-99446c6fd6b1" />
<img width="3840" height="1026" alt="Screenshot_2026-07-20_18-27-10" src="https://github.com/user-attachments/assets/a60f88a8-7116-4d8f-950f-0c07372ef966" />
<img width="3840" height="1918" alt="Screenshot_2026-07-20_18-27-42" src="https://github.com/user-attachments/assets/87ec7adb-83d9-49d7-939a-0c24a2993739" />
<img width="3840" height="1418" alt="Screenshot_2026-07-20_18-28-15" src="https://github.com/user-attachments/assets/405c3ab5-be32-43ab-b0c5-0adc972ff848" />
<img width="3840" height="1284" alt="Screenshot_2026-07-20_18-28-42" src="https://github.com/user-attachments/assets/ceb87693-66d3-4cd7-b0cb-3dea88f82cf7" />
<img width="1918" height="1924" alt="Screenshot_2026-07-20_18-29-13" src="https://github.com/user-attachments/assets/ef3ad247-5dec-40ce-a05a-f20d1b6bc5ab" />